### PR TITLE
Update CAPTCHA_FAILED_LOGIN_COUNT to 0 in config-site.php

### DIFF
--- a/imageroot/templates/config-site.php
+++ b/imageroot/templates/config-site.php
@@ -24,4 +24,4 @@ $config['IMAP_HOST'] = '{{imap_host}}';
 $config['IMAP_PORT'] =  993;
 $config['IMAP_SSL'] = true;
 
-$config['CAPTCHA_FAILED_LOGIN_COUNT'] = 3;
+$config['CAPTCHA_FAILED_LOGIN_COUNT'] = 0;


### PR DESCRIPTION
This pull request updates the `CAPTCHA_FAILED_LOGIN_COUNT` variable in the `config-site.php` file to 0. This change ensures that the CAPTCHA is not triggered after a certain number of failed login attempts.

NethServer/dev#6895