### PR TITLE
Allow the bulk and selective email restoration by  smtp

### DIFF
--- a/imageroot/actions/configure-module/10configure
+++ b/imageroot/actions/configure-module/10configure
@@ -23,5 +23,5 @@ providers = agent.list_service_providers(rdb, 'imap', 'tcp', {
 })
 
 if providers:
-    # Set the IMAP_HOST (IPV4) environment variable to the host of the first provider
-    agent.set_env("IMAP_HOST", providers[0]["host"])
+    # Set the PROVIDER_IP (IPV4) environment variable to the host of the first provider
+    agent.set_env("PROVIDER_IP", providers[0]["host"])

--- a/imageroot/bin/expand-configuration
+++ b/imageroot/bin/expand-configuration
@@ -8,8 +8,8 @@
 import os
 import glob
 import json
-# import sys
-# import subprocess
+import agent
+
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 for file in glob.iglob("piler_etc/*"):
@@ -21,9 +21,22 @@ jenv = Environment(
     keep_trailing_newline=True,
 )
 
+# the first start is for mail smtp validation only, MAIL_SERVER is not set
+if os.environ.get("MAIL_SERVER", ''):
+    #Connect to redis
+    rdb = agent.redis_connect(use_replica=True)
+
+    providers = agent.list_service_providers(rdb, 'imap', 'tcp', {
+        'module_uuid': os.environ["MAIL_SERVER"],
+    })
+
+    if providers and providers[0]["host"] != os.environ.get("PROVIDER_IP", ''):
+        # Set the PROVIDER_IP (IPV4) environment variable to the host of the first provider
+        agent.set_env("PROVIDER_IP", providers[0]["host"])
+
 properties = {
-    "host":  os.environ.get("TRAEFIK_HOST",''),
-    "provider_ip": os.environ.get("PROVIDER_IP",''),
+    "host":  os.environ["TRAEFIK_HOST"],
+    "provider_ip": os.environ["PROVIDER_IP"],
 }
 
 json_properties = json.dumps(properties)
@@ -37,4 +50,3 @@ template = jenv.get_template('config-site.php')
 output = template.render(json.loads(json_properties))
 with open("piler_etc/config-site.php","w") as f:
     f.write(output)
-

--- a/imageroot/bin/expand-configuration
+++ b/imageroot/bin/expand-configuration
@@ -23,7 +23,7 @@ jenv = Environment(
 
 properties = {
     "host":  os.environ.get("TRAEFIK_HOST",''),
-    "imap_host": os.environ.get("IMAP_HOST",''),
+    "provider_ip": os.environ.get("PROVIDER_IP",''),
 }
 
 json_properties = json.dumps(properties)

--- a/imageroot/events/mail-settings-changed/80start_services
+++ b/imageroot/events/mail-settings-changed/80start_services
@@ -13,5 +13,16 @@ import os
 event = json.load(sys.stdin)
 
 if event['module_uuid'] == os.getenv('MAIL_SERVER', ''):
-   # Restart to apply changed settings
+   # Restart to apply changed settings but first retrieve the IP of the first provider
+
+   #Connect to redis
+   rdb = agent.redis_connect()
+
+   providers = agent.list_service_providers(rdb, 'imap', 'tcp', {
+      'module_uuid': event['module_uuid'],
+   })
+
+   if providers:
+      # Set the PROVIDER_IP (IPV4) environment variable to the host of the first provider
+      agent.set_env("PROVIDER_IP", providers[0]["host"])
    agent.run_helper("systemctl", "--user", "try-restart", "piler.service").check_returncode()

--- a/imageroot/events/mail-settings-changed/80start_services
+++ b/imageroot/events/mail-settings-changed/80start_services
@@ -13,16 +13,5 @@ import os
 event = json.load(sys.stdin)
 
 if event['module_uuid'] == os.getenv('MAIL_SERVER', ''):
-   # Restart to apply changed settings but first retrieve the IP of the first provider
-
-   #Connect to redis
-   rdb = agent.redis_connect()
-
-   providers = agent.list_service_providers(rdb, 'imap', 'tcp', {
-      'module_uuid': event['module_uuid'],
-   })
-
-   if providers:
-      # Set the PROVIDER_IP (IPV4) environment variable to the host of the first provider
-      agent.set_env("PROVIDER_IP", providers[0]["host"])
+   # Restart to apply changed settings
    agent.run_helper("systemctl", "--user", "try-restart", "piler.service").check_returncode()

--- a/imageroot/templates/config-site.php
+++ b/imageroot/templates/config-site.php
@@ -7,6 +7,10 @@ $config['SITE_URL'] = 'https://{{host}}/';
 $config['SMTP_DOMAIN'] = $config[SITE_NAME_CONST];
 $config['SMTP_FROMADDR'] = 'no-reply@' . $config[SITE_NAME_CONST];
 $config['ADMIN_EMAIL'] = 'admin@' . $config[SITE_NAME_CONST];
+$config['SMARTHOST'] = '{{provider_ip}}';
+$config['SMARTHOST_PORT'] = 25;
+$config['SMARTHOST_USER'] = '';
+$config['SMARTHOST_PASSWORD'] = '';
 
 $config['DECRYPT_BINARY'] = '/usr/bin/pilerget';
 $config['DECRYPT_ATTACHMENT_BINARY'] = '/usr/bin/pileraget';

--- a/imageroot/templates/config-site.php
+++ b/imageroot/templates/config-site.php
@@ -20,8 +20,8 @@ $config['DB_PASSWORD'] = 'piler';
 $config['ENABLE_MEMCACHED'] = 1;
 $memcached_server = ['memcached', 11211];
 
-$config['ENABLE_IMAP_AUTH'] = 1;
-$config['RESTORE_OVER_IMAP'] = 1;
+$config['ENABLE_IMAP_AUTH'] = 0;
+$config['RESTORE_OVER_IMAP'] = 0;
 $config['IMAP_RESTORE_FOLDER_INBOX'] = 'INBOX';
 $config['IMAP_RESTORE_FOLDER_SENT'] = 'Sent';
 $config['IMAP_HOST'] = '{{provider_ip}}';

--- a/imageroot/templates/config-site.php
+++ b/imageroot/templates/config-site.php
@@ -20,7 +20,7 @@ $config['ENABLE_IMAP_AUTH'] = 1;
 $config['RESTORE_OVER_IMAP'] = 1;
 $config['IMAP_RESTORE_FOLDER_INBOX'] = 'INBOX';
 $config['IMAP_RESTORE_FOLDER_SENT'] = 'Sent';
-$config['IMAP_HOST'] = '{{imap_host}}';
+$config['IMAP_HOST'] = '{{provider_ip}}';
 $config['IMAP_PORT'] =  993;
 $config['IMAP_SSL'] = true;
 


### PR DESCRIPTION
This pull request updates the environment variable names in the codebase to use "PROVIDER_IP" instead of "IMAP_HOST" for the IMAP host configuration. This change ensures consistency and clarity in the codebase because imap host === smtp host

Allow the auditor to restore by smtp on the IP of VPN  without authentication (unencrypted on 25), we have no more imap authentication because we need to make an event during the domain creation/deletion in the mail server and also create a map action with email alias and username.

Note: you can select one email or the bulk restoration, everything is sent by smtp as an email, however the domain must be listed inside the piler UI
![image](https://github.com/NethServer/ns8-piler/assets/3164851/e34f0ab4-8a39-46fd-81fe-8a3b7512eeda)


![image](https://github.com/NethServer/ns8-piler/assets/3164851/9cfc6ed7-d35c-495e-9cea-ef276cf77113)

For restoration You have to set the email where to send the emails, the cons is that everything is sent to inbox, with IMAP recovering  it seems that piler respects `inbox` and `sent`

https://github.com/jsuto/piler/issues/29


refs: https://github.com/NethServer/dev/issues/6895