### PR TITLE
Add option to wait between email importation

### DIFF
--- a/imageroot/bin/import-emails
+++ b/imageroot/bin/import-emails
@@ -39,7 +39,7 @@ if providers:
 
             subprocess.run([
                 '/usr/bin/podman', 'exec', '-w', '/var/piler/imap', '-u', 'piler', 'piler-app',
-                '/usr/bin/pilerimport', '-i',  ip_address, '-u',  f'{user}*vmail', '-p', password, '-P', '993'
+                '/usr/bin/pilerimport', '-Z', '200', '-i',  ip_address, '-u',  f'{user}*vmail', '-p', password, '-P', '993'
             ])
         except Exception as e:
             print(f"### Error to import {user} to {os.environ['MODULE_ID']}: {e}", file=sys.stderr)


### PR DESCRIPTION
This pull request adds a new option to the `pilerimport` command in the `import-emails` script. The new option `-Z` allows specifying a delay of 200ms between each email importation. This can be useful in scenarios where importing emails too quickly can cause issues.

https://github.com/NethServer/dev/issues/6895