### PR TITLE
Add timestamp options for importing emails

### DIFF
--- a/imageroot/bin/import-emails
+++ b/imageroot/bin/import-emails
@@ -9,7 +9,24 @@ import subprocess
 import sys
 import os
 import agent
+import argparse
 
+parser = argparse.ArgumentParser(description='Script for importing user mailboxes from an IMAP server into the mail piler archive')
+parser.add_argument('-A', '--after', metavar='AFTER_TIMESTAMP', type=str,
+                    help='Import emails after the specified value (unix timestamp)')
+parser.add_argument('-B', '--before', metavar='BEFORE_TIMESTAMP', type=str,
+                    help='Import emails before the specified value (unix timestamp)')
+
+args = parser.parse_args()
+
+timestamp = ''
+
+if args.after is not None:
+    print("Import emails after timestamp:", args.after,  file=sys.stderr)
+    timestamp = '-A '+args.after
+elif args.before is not None:
+    print("Import emails before timestamp:", args.before,  file=sys.stderr)
+    timestamp = '-B '+args.before
 
 rdb = agent.redis_connect()
 
@@ -39,9 +56,8 @@ if providers:
 
             subprocess.run([
                 '/usr/bin/podman', 'exec', '-w', '/var/piler/imap', '-u', 'piler', 'piler-app',
-                '/usr/bin/pilerimport', '-i',  ip_address, '-u',  f'{user}*vmail', '-p', password, '-P', '993'
+                '/usr/bin/pilerimport', timestamp , '-i',  ip_address, '-u',  f'{user}*vmail', '-p', password, '-P', '993'
             ])
         except Exception as e:
             print(f"### Error to import {user} to {os.environ['MODULE_ID']}: {e}", file=sys.stderr)
             continue
-

--- a/imageroot/bin/import-emails
+++ b/imageroot/bin/import-emails
@@ -19,14 +19,14 @@ parser.add_argument('-B', '--before', metavar='BEFORE_TIMESTAMP', type=str,
 
 args = parser.parse_args()
 
-timestamp = ''
+timestamp = []
 
 if args.after is not None:
     print("Import emails after timestamp:", args.after,  file=sys.stderr)
-    timestamp = '-A '+args.after
+    timestamp += ['-A', args.after]
 elif args.before is not None:
     print("Import emails before timestamp:", args.before,  file=sys.stderr)
-    timestamp = '-B '+args.before
+    timestamp += ['-B', args.before]
 
 rdb = agent.redis_connect()
 
@@ -56,7 +56,7 @@ if providers:
 
             subprocess.run([
                 '/usr/bin/podman', 'exec', '-w', '/var/piler/imap', '-u', 'piler', 'piler-app',
-                '/usr/bin/pilerimport', '-Z', '200', timestamp , '-i',  ip_address, '-u',  f'{user}*vmail', '-p', password, '-P', '993'
+                '/usr/bin/pilerimport', '-Z', '200', *timestamp , '-i',  ip_address, '-u',  f'{user}*vmail', '-p', password, '-P', '993'
             ])
         except Exception as e:
             print(f"### Error to import {user} to {os.environ['MODULE_ID']}: {e}", file=sys.stderr)


### PR DESCRIPTION
This pull request adds timestamp options for importing emails from an IMAP server into the mail piler archive. Users can now specify a timestamp to import emails after or before a certain value using the `-A` and `-B` flags respectively. This provides more flexibility and control over the import process.

```
[piler2@r3-pve state]$ ../bin/import-emails -h
usage: import-emails [-h] [-A AFTER_TIMESTAMP] [-B BEFORE_TIMESTAMP]

Script for importing user mailboxes from an IMAP server into the mail piler archive

options:
  -h, --help            show this help message and exit
  -A AFTER_TIMESTAMP, --after AFTER_TIMESTAMP
                        import emails after the specified value (unix timestamp)
  -B BEFORE_TIMESTAMP, --before BEFORE_TIMESTAMP
                        import emails before the specified value (unix timestamp)
```

```
../bin/import-emails -B 1
../bin/import-emails -A 1
```

https://github.com/NethServer/dev/issues/6895