### PR TITLE
Add queuedir configuration for purging emails cron job

### DIFF
--- a/imageroot/templates/piler.conf
+++ b/imageroot/templates/piler.conf
@@ -47,3 +47,4 @@ username=piler
 verbosity=1
 workdir=/var/piler/tmp
 mysqlhost=127.0.0.1
+queuedir=/var/piler/store


### PR DESCRIPTION
This pull request adds the `queuedir` configuration to the `piler.conf` file. This configuration is necessary for the purging emails cron job to function correctly.

https://github.com/NethServer/dev/issues/6895