### PR TITLE
Update docker image versions in build script

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -35,7 +35,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=node:fwadm traefik@node:routeadm mail@any:mailadm" \
     --label="org.nethserver.tcp-ports-demand=2" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/sutoj/piler:1.4.6 docker.io/mariadb:10.11.9 docker.io/memcached:1.6.32-alpine" \
+    --label="org.nethserver.images=docker.io/sutoj/piler:1.4.6 docker.io/mariadb:10.11.9 docker.io/memcached:1.6.32-alpine docker.io/manticoresearch/manticore:6.3.6" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/build-images.sh
+++ b/build-images.sh
@@ -35,7 +35,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=node:fwadm traefik@node:routeadm mail@any:mailadm" \
     --label="org.nethserver.tcp-ports-demand=2" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/sutoj/piler:1.4.4 docker.io/mariadb:10.11.7 docker.io/memcached:1.6.26-alpine" \
+    --label="org.nethserver.images=docker.io/sutoj/piler:1.4.6 docker.io/mariadb:10.11.9 docker.io/memcached:1.6.32-alpine" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/build-images.sh
+++ b/build-images.sh
@@ -35,7 +35,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=node:fwadm traefik@node:routeadm mail@any:mailadm" \
     --label="org.nethserver.tcp-ports-demand=2" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/sutoj/piler:1.4.6 docker.io/mariadb:10.11.9 docker.io/memcached:1.6.32-alpine docker.io/manticoresearch/manticore:6.3.6" \
+    --label="org.nethserver.images=docker.io/sutoj/piler:1.4.6 docker.io/mariadb:10.11.9 docker.io/memcached:1.6.32-alpine docker.io/manticoresearch/manticore:6.3.2" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/imageroot/state/manticore/manticore.conf
+++ b/imageroot/state/manticore/manticore.conf
@@ -1,0 +1,95 @@
+## Feel free to customize the config, eg. set the charset_table to your choice, etc.
+
+index piler1
+{
+    type = rt
+    path = /var/lib/manticore/piler1
+    rt_mem_limit = 512M
+    stored_fields =
+    min_word_len = 1
+    min_prefix_len = 5
+    #charset_table  = 0..9, english, _,
+    # See https://manual.manticoresearch.com/Creating_an_index/Data_types#Row-wise-and-columnar-attribute-storages
+    # if you want to enable columnar storage
+    # columnar_attrs = *
+    rt_field = sender
+    rt_field = rcpt
+    rt_field = senderdomain
+    rt_field = rcptdomain
+    rt_field = subject
+    rt_field = body
+    rt_field = attachment_types
+    rt_attr_bigint = arrived
+    rt_attr_bigint = sent
+    rt_attr_uint = size
+    rt_attr_uint = direction
+    rt_attr_uint = folder
+    rt_attr_uint = attachments
+}
+
+index tag1
+{
+    type = rt
+    path = /var/lib/manticore/tag1
+    rt_mem_limit = 16M
+    stored_fields = tag
+    min_word_len = 2
+    min_prefix_len = 5
+    #charset_table  = 0..9, english, _,
+    rt_field = tag
+    rt_attr_bigint = mid
+    rt_attr_uint = uid
+}
+
+index note1
+{
+    type = rt
+    path = /var/lib/manticore/note1
+    rt_mem_limit = 16M
+    stored_fields = note
+    min_word_len = 2
+    min_prefix_len = 5
+    #charset_table  = 0..9, english, _,
+    rt_field = note
+    rt_attr_bigint = mid
+    rt_attr_uint = uid
+}
+
+index audit1
+{
+    type = rt
+    path = /var/lib/manticore/audit1
+    rt_mem_limit = 16M
+    stored_fields = *
+    min_word_len = 2
+    min_prefix_len = 5
+    #charset_table  = 0..9, english, _,
+    rt_field = email
+    rt_field = ipaddr
+    rt_field = description
+    rt_attr_bigint = ts
+    rt_attr_bigint = meta_id
+    rt_attr_uint = action
+}
+
+searchd
+{
+    listen                  = 0.0.0.0:9312
+    listen                  = 0.0.0.0:9306:mysql
+    listen                  = 0.0.0.0:9307:mysql_readonly
+    log                     = /var/lib/manticore/manticore.log
+    binlog_max_log_size     = 256M
+    binlog_path             = /var/lib/manticore
+    binlog_flush            = 2
+    query_log               = /var/lib/manticore/query.log
+    network_timeout         = 5
+    pid_file                = /var/lib/manticore/manticore.pid
+    seamless_rotate         = 1
+    preopen_tables          = 1
+    unlink_old              = 1
+    thread_stack            = 512k
+    # https://manticoresearch.com/blog/manticoresearch-buddy-intro/
+    # Give a value to the buddy_path variable to enable manticore-buddy
+    buddy_path              =
+    rt_flush_period         = 300
+}

--- a/imageroot/state/manticore/manticore.conf
+++ b/imageroot/state/manticore/manticore.conf
@@ -1,95 +1,24 @@
-## Feel free to customize the config, eg. set the charset_table to your choice, etc.
-
-index piler1
-{
-    type = rt
-    path = /var/lib/manticore/piler1
-    rt_mem_limit = 512M
-    stored_fields =
-    min_word_len = 1
-    min_prefix_len = 5
-    #charset_table  = 0..9, english, _,
-    # See https://manual.manticoresearch.com/Creating_an_index/Data_types#Row-wise-and-columnar-attribute-storages
-    # if you want to enable columnar storage
-    # columnar_attrs = *
-    rt_field = sender
-    rt_field = rcpt
-    rt_field = senderdomain
-    rt_field = rcptdomain
-    rt_field = subject
-    rt_field = body
-    rt_field = attachment_types
-    rt_attr_bigint = arrived
-    rt_attr_bigint = sent
-    rt_attr_uint = size
-    rt_attr_uint = direction
-    rt_attr_uint = folder
-    rt_attr_uint = attachments
-}
-
-index tag1
-{
-    type = rt
-    path = /var/lib/manticore/tag1
-    rt_mem_limit = 16M
-    stored_fields = tag
-    min_word_len = 2
-    min_prefix_len = 5
-    #charset_table  = 0..9, english, _,
-    rt_field = tag
-    rt_attr_bigint = mid
-    rt_attr_uint = uid
-}
-
-index note1
-{
-    type = rt
-    path = /var/lib/manticore/note1
-    rt_mem_limit = 16M
-    stored_fields = note
-    min_word_len = 2
-    min_prefix_len = 5
-    #charset_table  = 0..9, english, _,
-    rt_field = note
-    rt_attr_bigint = mid
-    rt_attr_uint = uid
-}
-
-index audit1
-{
-    type = rt
-    path = /var/lib/manticore/audit1
-    rt_mem_limit = 16M
-    stored_fields = *
-    min_word_len = 2
-    min_prefix_len = 5
-    #charset_table  = 0..9, english, _,
-    rt_field = email
-    rt_field = ipaddr
-    rt_field = description
-    rt_attr_bigint = ts
-    rt_attr_bigint = meta_id
-    rt_attr_uint = action
-}
-
 searchd
 {
-    listen                  = 0.0.0.0:9312
-    listen                  = 0.0.0.0:9306:mysql
-    listen                  = 0.0.0.0:9307:mysql_readonly
-    log                     = /var/lib/manticore/manticore.log
-    binlog_max_log_size     = 256M
-    binlog_path             = /var/lib/manticore
-    binlog_flush            = 2
-    query_log               = /var/lib/manticore/query.log
-    network_timeout         = 5
-    pid_file                = /var/lib/manticore/manticore.pid
-    seamless_rotate         = 1
-    preopen_tables          = 1
-    unlink_old              = 1
-    thread_stack            = 512k
-    # https://manticoresearch.com/blog/manticoresearch-buddy-intro/
-    # Give a value to the buddy_path variable to enable manticore-buddy
-    buddy_path              =
-    rt_flush_period         = 300
+   agent_connect_timeout   = 3000
+   agent_query_timeout     = 9000
+   listen                  = 9306:mysql
+   listen                  = 9307:mysql_readonly
+   log                     = /var/lib/manticore/manticore.log
+   binlog_flush            = 2
+   binlog_path             = /var/lib/manticore
+   binlog_max_log_size     = 256M
+   data_dir                = /var/lib/manticore
+   query_log               = /var/lib/manticore/manticore.log
+   network_timeout         = 5
+   max_packet_size         = 32M
+   pid_file                = /var/lib/manticore/manticore.pid
+   seamless_rotate         = 1
+   preopen_tables          = 1
+   unlink_old              = 1
+   thread_stack            = 512k
+   # https://manticoresearch.com/blog/manticoresearch-buddy-intro/
+   # Comment out the next line if you want to enable manticore-buddy
+   buddy_path              =
+   rt_flush_period         = 300
 }

--- a/imageroot/systemd/user/manticore-app.service
+++ b/imageroot/systemd/user/manticore-app.service
@@ -17,7 +17,7 @@ ExecStartPre=/bin/rm -f %t/manticore-app.pid %t/manticore-app.ctr-id
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/manticore-app.pid \
     --cidfile %t/manticore-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/piler.pod-id --replace -d --name manticore-app \
-    --volume ./manticore/manticore.conf:/etc/manticoresearch/manticore.conf:Z \
+    --volume %S/state/manticore/manticore.conf:/etc/manticoresearch/manticore.conf:Z \
     --volume piler_manticore:/var/lib/manticore:Z \
     ${MANTICORE_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/manticore-app.ctr-id -t 10

--- a/imageroot/systemd/user/manticore-app.service
+++ b/imageroot/systemd/user/manticore-app.service
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+[Unit]
+Description=Podman manticore-app.service
+BindsTo=piler.service
+After=piler.service
+
+[Service]
+Environment=PODMAN_SYSTEMD_UNIT=%n
+EnvironmentFile=%S/state/environment
+Restart=always
+TimeoutStopSec=70
+ExecStartPre=/bin/rm -f %t/manticore-app.pid %t/manticore-app.ctr-id
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/manticore-app.pid \
+    --cidfile %t/manticore-app.ctr-id --cgroups=no-conmon \
+    --pod-id-file %t/piler.pod-id --replace -d --name manticore-app \
+    --volume ./manticore/manticore.conf:/etc/manticoresearch/manticore.conf:Z \
+    --volume piler_manticore:/var/lib/manticore:Z \
+    ${MANTICORE_IMAGE}
+ExecStop=/usr/bin/podman stop --ignore --cidfile %t/manticore-app.ctr-id -t 10
+ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/manticore-app.ctr-id
+ExecReload=/usr/bin/podman kill -s HUP manticore-app
+SyslogIdentifier=%u
+PIDFile=%t/manticore-app.pid
+Type=forking
+
+[Install]
+WantedBy=default.target

--- a/imageroot/systemd/user/piler-app.service
+++ b/imageroot/systemd/user/piler-app.service
@@ -23,14 +23,14 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/piler-app.pid \
     --volume %S/state/piler_etc/config-site.php:/etc/piler/config-site.php:Z \
     --volume %S/state/piler_etc/piler.conf:/etc/piler/piler.conf:Z \
     --volume piler_etc:/etc/piler:Z \
-    --volume piler_manticore:/var/piler/manticore:Z \
     --volume piler_store:/var/piler/store:Z \
     --env MYSQL_DATABASE=piler \
     --env MYSQL_USER=piler \
     --env MYSQL_PASSWORD=piler \
     --env MYSQL_HOSTNAME=127.0.0.1 \
     --env PILER_HOSTNAME=${TRAEFIK_HOST} \
-    --env MEMCACHED_HOST=127.0.0.1 \
+    --env MEMCACHED_HOSTNAME=127.0.0.1 \
+    --env MANTICORE_HOSTNAME=127.0.0.1 \
     ${PILER_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/piler-app.ctr-id -t 10
 ExecReload=/usr/local/bin/runagent expand-configuration

--- a/imageroot/systemd/user/piler-app.service
+++ b/imageroot/systemd/user/piler-app.service
@@ -31,6 +31,10 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/piler-app.pid \
     --env PILER_HOSTNAME=${TRAEFIK_HOST} \
     --env MEMCACHED_HOSTNAME=127.0.0.1 \
     --env MANTICORE_HOSTNAME=127.0.0.1 \
+    --env MULTITENANCY=0 \
+    --env MULTINODES=0 \
+    --env ENCRYPTED_SQL=0 \
+    --env DYNAMIC_INDEX=1 \
     --env RT=1 \
     ${PILER_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/piler-app.ctr-id -t 10

--- a/imageroot/systemd/user/piler-app.service
+++ b/imageroot/systemd/user/piler-app.service
@@ -31,6 +31,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/piler-app.pid \
     --env PILER_HOSTNAME=${TRAEFIK_HOST} \
     --env MEMCACHED_HOSTNAME=127.0.0.1 \
     --env MANTICORE_HOSTNAME=127.0.0.1 \
+    --env RT=1 \
     ${PILER_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/piler-app.ctr-id -t 10
 ExecReload=/usr/local/bin/runagent expand-configuration

--- a/imageroot/systemd/user/piler.service
+++ b/imageroot/systemd/user/piler.service
@@ -10,8 +10,8 @@
 
 [Unit]
 Description=Podman piler.service
-Requires=mariadb-app.service piler-app.service memcached-app.service
-Before=mariadb-app.service piler-app.service memcached-app.service
+Requires=mariadb-app.service piler-app.service memcached-app.service manticore-app.service
+Before=mariadb-app.service piler-app.service memcached-app.service manticore-app.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=-%S/state/environment

--- a/imageroot/templates/config-site.php
+++ b/imageroot/templates/config-site.php
@@ -29,3 +29,6 @@ $config['IMAP_PORT'] =  993;
 $config['IMAP_SSL'] = true;
 
 $config['CAPTCHA_FAILED_LOGIN_COUNT'] = 0;
+
+$config['SPHINX_HOSTNAME'] = '127.0.0.1:9306';
+$config['SPHINX_HOSTNAME_READONLY'] = '127.0.0.1:9307';

--- a/imageroot/templates/piler.conf
+++ b/imageroot/templates/piler.conf
@@ -48,3 +48,4 @@ verbosity=1
 workdir=/var/piler/tmp
 mysqlhost=127.0.0.1
 queuedir=/var/piler/store
+sphxhost=127.0.0.1


### PR DESCRIPTION
This pull request updates the docker image versions in the build script. Specifically, it updates the versions of the `piler`, `mariadb`, and `memcached` images to `1.4.6`, `10.11.9`, and `1.6.32-alpine` respectively.

```
Oct 30 09:39:54 r3-pve.rocky9-pve3.org piler-app[302899]: using config file '/etc/piler/manticore.conf'...
Oct 30 09:39:54 r3-pve.rocky9-pve3.org piler-app[302899]: FATAL: no tables found in config file '/etc/piler/manticore.conf'
Oct 30 09:39:54 r3-pve.rocky9-pve3.org agent@piler2[301082]: Error: can only create exec sessions on running containers: container state improper
```



not a bug, it is a feature, we need a fourth containers

https://github.com/jsuto/piler/blob/0f662c7d069a665afa999add5ef761766eb1e646/docker/docker-compose.yaml#L27