### PR TITLE
Instruction on how rebuild the manticore index

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,15 @@ Previous emails are sent automatically one time to piler after the first configu
 
     runagent -m piler1 import-emails
 
+## Recreate The Index Data Files
+
+This is a troubleshooting task, use it only when you have to or you are advised to rebuild the manticore index from scratch.
+
+Piler relies heavily on the manticore index data. The reindex utility is for healing it if anything goes wrong.
+
+    runagent -m piler1 podman exec -w /var/piler/imap piler-app reindex -a -p
+
+
+
+
 Piler understands and manage  duplicated emails.


### PR DESCRIPTION
This pull request adds new documentation to the `README.md` file, specifically providing instructions for recreating the Manticore index data files. This section is intended for troubleshooting and describes how to use the `reindex` utility if the index becomes corrupted or needs to be rebuilt.

Documentation update:

* Added a new section to the `README.md` explaining when and how to use the `reindex` utility to rebuild the Manticore index, including the exact command to run.