### PR TITLE
Fix email reindexing command execution

### DIFF
--- a/imageroot/bin/reindexing-emails
+++ b/imageroot/bin/reindexing-emails
@@ -14,7 +14,7 @@ if podman volume inspect piler_manticore > /dev/null 2>&1; then
     podman volume rm -f piler_manticore
     # start import-emails the change of sphinx version need to reindex the emails
     echo "Reindexing emails now ..."
-    podman exec -w /var/piler/imap piler-app reindex -a -p
+    exec podman exec -w /var/piler/imap piler-app reindex -a -p
 else 
     echo "No need to reindexing emails, previous version is not 1.4.4"
 fi


### PR DESCRIPTION
Ensure the email reindexing command executes properly by using `exec` to replace the shell with the command in the reindexing script.