### PR TITLE
Add support for NS8 volume management

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -34,6 +34,7 @@ buildah add "${container}" ui/dist /ui
 buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=node:fwadm traefik@node:routeadm mail@any:mailadm" \
     --label="org.nethserver.tcp-ports-demand=2" \
+    --label="org.nethserver.volumes=piler_store" \
     --label="org.nethserver.rootfull=0" \
     --label="org.nethserver.min-core=3.12.4-0" \
     --label="org.nethserver.images=docker.io/sutoj/piler:1.4.8 docker.io/mariadb:10.11.16 docker.io/memcached:1.6.41-alpine docker.io/manticoresearch/manticore:10.1.0" \

--- a/imageroot/systemd/user/piler-app.service
+++ b/imageroot/systemd/user/piler-app.service
@@ -23,7 +23,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/piler-app.pid \
     --volume ./piler_etc/config-site.php:/etc/piler/config-site.php:z \
     --volume ./piler_etc/piler.conf:/etc/piler/piler.conf:z \
     --volume piler_etc:/etc/piler:z \
-    --volume piler_store:/var/piler/store:z \
+    --volume piler_store:/var/piler/store \
     --env MYSQL_DATABASE=piler \
     --env MYSQL_USER=piler \
     --env MYSQL_PASSWORD=piler \


### PR DESCRIPTION
## Add support for NS8 volume management

This PR updates the module to support the new volume management feature introduced in NS8 Core 3.14.

### Changes

- Added the `org.nethserver.volumes` image label to declare which named volumes are suitable for placement on additional disks.
- Reviewed bind mounts and data directories for consistent SELinux labeling, removing the `:z` flag where appropriate on volumes listed in `org.nethserver.volumes`.

The module works but more tests would be needed.

https://github.com/NethServer/dev/issues/7941