### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/manticore-app.service
+++ b/imageroot/systemd/user/manticore-app.service
@@ -10,8 +10,8 @@ After=piler.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/manticore-app.pid %t/manticore-app.ctr-id

--- a/imageroot/systemd/user/mariadb-app.service
+++ b/imageroot/systemd/user/mariadb-app.service
@@ -11,15 +11,15 @@ Before=piler-app.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/mariadb-app.pid %t/mariadb-app.ctr-id
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/mariadb-app.pid \
     --cidfile %t/mariadb-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/piler.pod-id --replace -d --name mariadb-app \
-    --env-file=%S/state/environment \
+    --env-file=%E/state/environment \
     --volume ../templates/piler.cnf:/etc/mysql/conf.d/piler.cnf:z \
     --volume mysql-data:/var/lib/mysql/:z \
     --env MARIADB_ROOT_PASSWORD=Nethesis,1234 \

--- a/imageroot/systemd/user/memcached-app.service
+++ b/imageroot/systemd/user/memcached-app.service
@@ -10,14 +10,14 @@ After=piler.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/memcached-app.pid %t/memcached-app.ctr-id
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/memcached-app.pid \
     --cidfile %t/memcached-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/piler.pod-id --replace -d --name memcached-app \
-    --env-file=%S/state/environment \
+    --env-file=%E/state/environment \
     ${MEMCACHED_IMAGE} \
     memcached -m 64
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/memcached-app.ctr-id -t 10

--- a/imageroot/systemd/user/piler-app.service
+++ b/imageroot/systemd/user/piler-app.service
@@ -10,8 +10,8 @@ After=piler.service mariadb-app.service memcached-app.service manticore-app.serv
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/mkdir -vp piler_etc templates

--- a/imageroot/systemd/user/piler.service
+++ b/imageroot/systemd/user/piler.service
@@ -14,7 +14,7 @@ Requires=mariadb-app.service piler-app.service memcached-app.service manticore-a
 Before=mariadb-app.service piler-app.service memcached-app.service manticore-app.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=-%S/state/environment
+EnvironmentFile=-%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/piler.pid %t/piler.pod-id


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host